### PR TITLE
fix: テキスト表現の改善 - アスタリスクから日本語表記へ変更 #32

### DIFF
--- a/src/components/ContentEditor.js
+++ b/src/components/ContentEditor.js
@@ -510,7 +510,7 @@ export default function ContentEditor({ mode, content, excelData, onClose }) {
             <div className="grid sm:grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
               <div>
                 <label className="block text-sm font-semibold text-gray-700 mb-2">
-                  タイトル *
+                  タイトル（必須）
                 </label>
                 <input
                   type="text"
@@ -826,7 +826,7 @@ export default function ContentEditor({ mode, content, excelData, onClose }) {
             
             <div>
               <label className="block text-sm font-semibold text-gray-700 mb-2">
-                本文 *
+                本文（必須）
               </label>
               <textarea
                 name="text"


### PR DESCRIPTION
## Summary
- フォームラベルのアスタリスク（*）を「（必須）」という日本語表記に変更
- より明確で分かりやすい表現に改善

## Changes Made
- `タイトル *` → `タイトル（必須）`
- `本文 *` → `本文（必須）`

## Purpose
Issue #32で指摘された「文章⋆」のような記号表現の適切性確認と改善の一環として、フォームの必須項目表示を改善しました。

アスタリスク記号（*）は：
- 視覚的に見落としやすい
- 日本語学習者にとって意味が不明確
- アクセシビリティの観点から課題がある

これらの理由から、明確な日本語表記「（必須）」に変更しました。

## Test Plan
- [x] 管理画面（/admin）でコンテンツ編集フォームを確認
- [x] タイトルと本文のラベルが正しく表示されることを確認
- [x] フォームの動作に問題がないことを確認

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)