### PR TITLE
「このサイトについて」ページ機能を実装

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,3 +62,13 @@ model QuestionOption {
 
   @@map("question_options")
 }
+
+model AboutPage {
+  id        String   @id @default(cuid())
+  content   String
+  images    Json?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@map("about_page")
+}

--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,149 +1,101 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Layout from '../../components/Layout';
+
 export default function About() {
+  const [aboutData, setAboutData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchAboutData();
+  }, []);
+
+  const fetchAboutData = async () => {
+    try {
+      const response = await fetch('/api/about');
+      if (!response.ok) {
+        throw new Error('データの取得に失敗しました');
+      }
+      const data = await response.json();
+      setAboutData(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderContent = (content) => {
+    if (!content) return null;
+
+    // 画像プレースホルダーを実際の画像に置換
+    const parts = content.split(/(\{\{IMAGE:\d+\}\})/);
+    return parts.map((part, index) => {
+      const match = part.match(/\{\{IMAGE:(\d+)\}\}/);
+      if (match && aboutData?.images) {
+        const imageIndex = parseInt(match[1], 10);
+        const image = aboutData.images[imageIndex];
+        if (image) {
+          return (
+            <img
+              key={index}
+              src={image}
+              alt={`画像 ${imageIndex + 1}`}
+              className="max-w-full h-auto my-4 rounded-lg shadow-lg"
+            />
+          );
+        }
+      }
+      // 改行を<br>に変換
+      return (
+        <span key={index}>
+          {part.split('\n').map((line, lineIndex) => (
+            <span key={lineIndex}>
+              {line}
+              {lineIndex < part.split('\n').length - 1 && <br />}
+            </span>
+          ))}
+        </span>
+      );
+    });
+  };
+
   return (
-    <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12 pb-safe-area-inset-bottom pb-6">
-      <h1 className="text-3xl font-bold text-gray-900 mb-8">
-        Fluency（流暢さ）について
-      </h1>
+    <Layout>
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <h1 className="text-4xl font-bold text-center mb-8 text-gray-800">
+          このサイトについて
+        </h1>
 
-      <div className="bg-white rounded-lg shadow-md p-8 mb-8">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
-          Fluencyとは何か
-        </h2>
-        <div className="text-gray-700 space-y-4">
-          <p>
-            <strong>Fluency（流暢さ）</strong>とは、言語を自然でスムーズに使える能力のことです。
-            第二言語学習において、fluencyは非常に重要な概念です。
-          </p>
-          <p>
-            読解におけるfluencyは、<strong>正確性</strong>、<strong>自動性</strong>、<strong>速度</strong>の
-            3つの要素から構成されます。速度は「語数/分（WPM: Words Per Minute）」で測定され、
-            日本語の場合は「標準語数」という概念を導入して計算しています。
-          </p>
-        </div>
-      </div>
-
-      <div className="grid md:grid-cols-3 gap-6 mb-8">
-        <div className="bg-blue-50 border-2 border-blue-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
-          <h3 className="text-2xl font-bold text-blue-900 mb-6">
-            正確性（Accuracy）
-          </h3>
-          <p className="text-blue-800 text-lg leading-relaxed">
-            文字、語彙、文法を正しく理解する能力。<br />
-            間違いなく読むことができるかどうかです。
-          </p>
-        </div>
-
-        <div className="bg-green-50 border-2 border-green-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
-          <h3 className="text-2xl font-bold text-green-900 mb-6">
-            自動性（Automaticity）
-          </h3>
-          <p className="text-green-800 text-lg leading-relaxed">
-            意識的な努力なしに読める能力。<br />
-            考えなくても自然に読めることです。
-          </p>
-        </div>
-
-        <div className="bg-purple-50 border-2 border-purple-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
-          <h3 className="text-2xl font-bold text-purple-900 mb-6">
-            速度（Rate）
-          </h3>
-          <p className="text-purple-800 text-lg leading-relaxed">
-            適切なスピードで読める能力。<br />
-            速すぎず遅すぎない自然な速度です。
-          </p>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-md p-8 mb-8">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
-          多読と速読の関係
-        </h2>
-        <div className="text-gray-700 space-y-4">
-          <h3 className="text-lg font-semibold text-gray-900">多読（Extensive Reading）</h3>
-          <p>
-            簡単な読み物を大量に読むことで、第二言語読解の総合的な力を伸ばす学習方法です。
-            特に流暢さと情意面での効果が期待できます。
-          </p>
-          <ul className="list-disc list-inside space-y-2">
-            <li>読み物は既知語率95-96％が適切</li>
-            <li>英語読解では98％が望ましい</li>
-            <li>楽しみながら読むことが重要</li>
-          </ul>
-
-          <h3 className="text-lg font-semibold text-gray-900 mt-6">速読（Speed Reading）</h3>
-          <p>
-            多読プログラム内で併用することで、読みの流暢さを高める相乗効果を発揮できます。
-          </p>
-          <ul className="list-disc list-inside space-y-2">
-            <li>読み物の既知語率は100％であるべき</li>
-            <li>文法項目もすべて既習であるべき</li>
-            <li>理解度よりも速度に重点を置く</li>
-          </ul>
-        </div>
-      </div>
-
-      <div className="bg-white rounded-lg shadow-md p-8">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
-          SuiReNの役割
-        </h2>
-        <div className="text-gray-700 space-y-4">
-          <p>
-            SuiReNは、速読練習を通じて日本語学習者の読解fluencyを向上させることを目的としています。
-          </p>
-          <p>
-            レベル別に設計されたコンテンツにより、学習者は自分のレベルに適した速読練習を行うことができます。
-            読了時間と理解度の測定により、学習者は自分の進歩を客観的に把握できます。
-          </p>
-          <p>
-            継続的な練習により、日本語を読む際の自動性が向上し、
-            より自然で流暢な読解能力の獲得が期待できます。
-          </p>
-        </div>
-      </div>
-      <div className="bg-white rounded-lg shadow-md p-8">
-        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
-          読書速度の測定方法
-        </h2>
-        <div className="text-gray-700 space-y-4">
-          <h3 className="text-lg font-semibold text-gray-900">標準語数とは？</h3>
-          <p>
-            日本語読み物の実質的な情報量を測るための指標です。
-            SuiReNでは、形態素解析に基づいた語彙単位でカウントし、
-            以下の重み付けを行っています：
-          </p>
-          <ul className="list-disc list-inside space-y-2 ml-4">
-            <li>漢字・カタカナ・英数字の語：1.0として計算</li>
-            <li>ひらがなのみの語（助詞など）：0.5として計算</li>
-          </ul>
-          
-          <h3 className="text-lg font-semibold text-gray-900 mt-6">速度の計算方法</h3>
-          <p>
-            読書速度 = 標準語数 ÷ 読書時間（分）
-          </p>
-          <p className="mt-2">
-            この計算方法により、日本語の特殊性を考慮した
-            公平な速度測定が可能になります。
-          </p>
-          
-          <h3 className="text-lg font-semibold text-gray-900 mt-6">目標速度の目安</h3>
-          <div className="mt-2">
-            <p className="font-semibold">日本語学習者：</p>
-            <ul className="list-disc list-inside space-y-1 ml-4">
-              <li>初級：50-100語/分</li>
-              <li>中級：100-200語/分</li>
-              <li>上級：200-300語/分</li>
-            </ul>
-            
-            <p className="font-semibold mt-4">日本語ネイティブスピーカー：</p>
-            <ul className="list-disc list-inside space-y-1 ml-4">
-              <li>小学生：100-200語/分</li>
-              <li>中学生：200-300語/分</li>
-              <li>高校生：300-400語/分</li>
-              <li>大学生・成人：400-600語/分</li>
-            </ul>
+        {loading && (
+          <div className="text-center py-12">
+            <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+            <p className="mt-4 text-gray-600">読み込み中...</p>
           </div>
-        </div>
+        )}
+
+        {error && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+            エラー: {error}
+          </div>
+        )}
+
+        {!loading && !error && (
+          <div className="bg-white rounded-lg shadow-lg p-8">
+            {aboutData?.content ? (
+              <div className="prose prose-lg max-w-none">
+                {renderContent(aboutData.content)}
+              </div>
+            ) : (
+              <p className="text-gray-500 text-center py-8">
+                まだコンテンツが登録されていません。
+              </p>
+            )}
+          </div>
+        )}
       </div>
-    </div>
+    </Layout>
   );
 }

--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Layout from '../../components/Layout';
 
 export default function About() {
   const [aboutData, setAboutData] = useState(null);
@@ -63,8 +62,7 @@ export default function About() {
   };
 
   return (
-    <Layout>
-      <div className="container mx-auto px-4 py-8 max-w-4xl">
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
         <h1 className="text-4xl font-bold text-center mb-8 text-gray-800">
           このサイトについて
         </h1>
@@ -95,7 +93,6 @@ export default function About() {
             )}
           </div>
         )}
-      </div>
-    </Layout>
+    </div>
   );
 }

--- a/src/app/about/page.js
+++ b/src/app/about/page.js
@@ -35,12 +35,17 @@ export default function About() {
       const match = part.match(/\{\{IMAGE:(\d+)\}\}/);
       if (match && aboutData?.images) {
         const imageIndex = parseInt(match[1], 10);
-        const image = aboutData.images[imageIndex];
-        if (image) {
+        const imageData = aboutData.images[imageIndex];
+        if (imageData) {
+          // imageDataがオブジェクトの場合はbase64プロパティを、文字列の場合はそのまま使用
+          const imageSrc = typeof imageData === 'object' && imageData.base64 
+            ? imageData.base64 
+            : imageData;
+            
           return (
             <img
               key={index}
-              src={image}
+              src={imageSrc}
               alt={`画像 ${imageIndex + 1}`}
               className="max-w-full h-auto my-4 rounded-lg shadow-lg"
             />

--- a/src/app/admin/page.js
+++ b/src/app/admin/page.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import ContentEditor from '../../components/ContentEditor';
 import LevelManager from '../../components/LevelManager';
+import AboutPageEditor from '../../components/AboutPageEditor';
 import { 
   LEVEL_CODES, 
   getLevelDisplayName,
@@ -23,7 +24,7 @@ export default function Admin() {
   const [showExcelUpload, setShowExcelUpload] = useState(false);
   const [excelUploadLoading, setExcelUploadLoading] = useState(false);
   const [excelData, setExcelData] = useState(null);
-  const [activeTab, setActiveTab] = useState('contents'); // 'contents' or 'levels'
+  const [activeTab, setActiveTab] = useState('contents'); // 'contents', 'levels', or 'about'
 
   const handleLogin = (e) => {
     e.preventDefault();
@@ -279,6 +280,16 @@ export default function Admin() {
           >
             レベル管理
           </button>
+          <button
+            onClick={() => setActiveTab('about')}
+            className={`py-2 px-1 border-b-2 font-medium text-sm ${
+              activeTab === 'about'
+                ? 'border-blue-500 text-blue-600'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+          >
+            このサイトについて
+          </button>
         </nav>
       </div>
 
@@ -451,6 +462,11 @@ export default function Admin() {
       {/* レベル管理タブ */}
       {activeTab === 'levels' && (
         <LevelManager />
+      )}
+
+      {/* このサイトについてタブ */}
+      {activeTab === 'about' && (
+        <AboutPageEditor />
       )}
 
       {/* Excel Upload Modal */}

--- a/src/app/api/about/route.js
+++ b/src/app/api/about/route.js
@@ -1,0 +1,82 @@
+import { NextResponse } from 'next/server';
+import prisma from '../../../lib/prisma';
+
+// GET: AboutPageの取得
+export async function GET() {
+  try {
+    if (!prisma) {
+      throw new Error('Database connection not available');
+    }
+
+    // AboutPageを取得（最初の1件のみ）
+    const aboutPage = await prisma.aboutPage.findFirst({
+      orderBy: { createdAt: 'desc' }
+    });
+
+    // データが存在しない場合はデフォルトのデータを返す
+    if (!aboutPage) {
+      return NextResponse.json({
+        id: null,
+        content: '',
+        images: null
+      });
+    }
+
+    return NextResponse.json(aboutPage);
+  } catch (error) {
+    console.error('AboutPage GET error:', error);
+    return NextResponse.json(
+      { error: 'このサイトについての情報の取得に失敗しました' },
+      { status: 500 }
+    );
+  }
+}
+
+// PUT: AboutPageの更新または作成
+export async function PUT(request) {
+  try {
+    const body = await request.json();
+    const { content, images } = body;
+
+    // バリデーション
+    if (content === undefined) {
+      return NextResponse.json(
+        { error: 'コンテンツが必要です' },
+        { status: 400 }
+      );
+    }
+
+    // 既存のAboutPageを取得
+    const existingAboutPage = await prisma.aboutPage.findFirst({
+      orderBy: { createdAt: 'desc' }
+    });
+
+    let aboutPage;
+    if (existingAboutPage) {
+      // 更新
+      aboutPage = await prisma.aboutPage.update({
+        where: { id: existingAboutPage.id },
+        data: {
+          content,
+          images: images || null
+        }
+      });
+    } else {
+      // 新規作成
+      aboutPage = await prisma.aboutPage.create({
+        data: {
+          content,
+          images: images || null
+        }
+      });
+    }
+
+    return NextResponse.json(aboutPage);
+  } catch (error) {
+    console.error('AboutPage PUT error:', error);
+    return NextResponse.json(
+      { error: 'このサイトについての情報の更新に失敗しました' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/fluency/page.js
+++ b/src/app/fluency/page.js
@@ -1,0 +1,149 @@
+export default function Fluency() {
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 sm:py-12 pb-safe-area-inset-bottom pb-6">
+      <h1 className="text-3xl font-bold text-gray-900 mb-8">
+        Fluency（流暢さ）について
+      </h1>
+
+      <div className="bg-white rounded-lg shadow-md p-8 mb-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
+          Fluencyとは何か
+        </h2>
+        <div className="text-gray-700 space-y-4">
+          <p>
+            <strong>Fluency（流暢さ）</strong>とは、言語を自然でスムーズに使える能力のことです。
+            第二言語学習において、fluencyは非常に重要な概念です。
+          </p>
+          <p>
+            読解におけるfluencyは、<strong>正確性</strong>、<strong>自動性</strong>、<strong>速度</strong>の
+            3つの要素から構成されます。速度は「語数/分（WPM: Words Per Minute）」で測定され、
+            日本語の場合は「標準語数」という概念を導入して計算しています。
+          </p>
+        </div>
+      </div>
+
+      <div className="grid md:grid-cols-3 gap-6 mb-8">
+        <div className="bg-blue-50 border-2 border-blue-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
+          <h3 className="text-2xl font-bold text-blue-900 mb-6">
+            正確性（Accuracy）
+          </h3>
+          <p className="text-blue-800 text-lg leading-relaxed">
+            文字、語彙、文法を正しく理解する能力。<br />
+            間違いなく読むことができるかどうかです。
+          </p>
+        </div>
+
+        <div className="bg-green-50 border-2 border-green-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
+          <h3 className="text-2xl font-bold text-green-900 mb-6">
+            自動性（Automaticity）
+          </h3>
+          <p className="text-green-800 text-lg leading-relaxed">
+            意識的な努力なしに読める能力。<br />
+            考えなくても自然に読めることです。
+          </p>
+        </div>
+
+        <div className="bg-purple-50 border-2 border-purple-200 rounded-lg p-8 shadow-lg hover:shadow-xl transition-shadow duration-300">
+          <h3 className="text-2xl font-bold text-purple-900 mb-6">
+            速度（Rate）
+          </h3>
+          <p className="text-purple-800 text-lg leading-relaxed">
+            適切なスピードで読める能力。<br />
+            速すぎず遅すぎない自然な速度です。
+          </p>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-md p-8 mb-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
+          多読と速読の関係
+        </h2>
+        <div className="text-gray-700 space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">多読（Extensive Reading）</h3>
+          <p>
+            簡単な読み物を大量に読むことで、第二言語読解の総合的な力を伸ばす学習方法です。
+            特に流暢さと情意面での効果が期待できます。
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>読み物は既知語率95-96％が適切</li>
+            <li>英語読解では98％が望ましい</li>
+            <li>楽しみながら読むことが重要</li>
+          </ul>
+
+          <h3 className="text-lg font-semibold text-gray-900 mt-6">速読（Speed Reading）</h3>
+          <p>
+            多読プログラム内で併用することで、読みの流暢さを高める相乗効果を発揮できます。
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>読み物の既知語率は100％であるべき</li>
+            <li>文法項目もすべて既習であるべき</li>
+            <li>理解度よりも速度に重点を置く</li>
+          </ul>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-lg shadow-md p-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
+          SuiReNの役割
+        </h2>
+        <div className="text-gray-700 space-y-4">
+          <p>
+            SuiReNは、速読練習を通じて日本語学習者の読解fluencyを向上させることを目的としています。
+          </p>
+          <p>
+            レベル別に設計されたコンテンツにより、学習者は自分のレベルに適した速読練習を行うことができます。
+            読了時間と理解度の測定により、学習者は自分の進歩を客観的に把握できます。
+          </p>
+          <p>
+            継続的な練習により、日本語を読む際の自動性が向上し、
+            より自然で流暢な読解能力の獲得が期待できます。
+          </p>
+        </div>
+      </div>
+      <div className="bg-white rounded-lg shadow-md p-8">
+        <h2 className="text-2xl font-semibold text-gray-900 mb-6">
+          読書速度の測定方法
+        </h2>
+        <div className="text-gray-700 space-y-4">
+          <h3 className="text-lg font-semibold text-gray-900">標準語数とは？</h3>
+          <p>
+            日本語読み物の実質的な情報量を測るための指標です。
+            SuiReNでは、形態素解析に基づいた語彙単位でカウントし、
+            以下の重み付けを行っています：
+          </p>
+          <ul className="list-disc list-inside space-y-2 ml-4">
+            <li>漢字・カタカナ・英数字の語：1.0として計算</li>
+            <li>ひらがなのみの語（助詞など）：0.5として計算</li>
+          </ul>
+          
+          <h3 className="text-lg font-semibold text-gray-900 mt-6">速度の計算方法</h3>
+          <p>
+            読書速度 = 標準語数 ÷ 読書時間（分）
+          </p>
+          <p className="mt-2">
+            この計算方法により、日本語の特殊性を考慮した
+            公平な速度測定が可能になります。
+          </p>
+          
+          <h3 className="text-lg font-semibold text-gray-900 mt-6">目標速度の目安</h3>
+          <div className="mt-2">
+            <p className="font-semibold">日本語学習者：</p>
+            <ul className="list-disc list-inside space-y-1 ml-4">
+              <li>初級：50-100語/分</li>
+              <li>中級：100-200語/分</li>
+              <li>上級：200-300語/分</li>
+            </ul>
+            
+            <p className="font-semibold mt-4">日本語ネイティブスピーカー：</p>
+            <ul className="list-disc list-inside space-y-1 ml-4">
+              <li>小学生：100-200語/分</li>
+              <li>中学生：200-300語/分</li>
+              <li>高校生：300-400語/分</li>
+              <li>大学生・成人：400-600語/分</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AboutPageEditor.js
+++ b/src/components/AboutPageEditor.js
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState, useEffect, useRef } from 'react';
+import { compressImage } from '../lib/image-compression';
+
+export default function AboutPageEditor() {
+  const [content, setContent] = useState('');
+  const [images, setImages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState('');
+  const fileInputRef = useRef(null);
+
+  useEffect(() => {
+    fetchAboutData();
+  }, []);
+
+  const fetchAboutData = async () => {
+    try {
+      const response = await fetch('/api/about');
+      if (!response.ok) throw new Error('データの取得に失敗しました');
+      
+      const data = await response.json();
+      setContent(data.content || '');
+      setImages(data.images || []);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccessMessage('');
+
+    try {
+      const response = await fetch('/api/about', {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          content,
+          images: images.length > 0 ? images : null,
+        }),
+      });
+
+      if (!response.ok) throw new Error('保存に失敗しました');
+      
+      setSuccessMessage('保存しました');
+      setTimeout(() => setSuccessMessage(''), 3000);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleImageUpload = async (e) => {
+    const files = Array.from(e.target.files);
+    if (files.length === 0) return;
+
+    const newImages = [...images];
+    
+    for (const file of files) {
+      try {
+        const compressedImage = await compressImage(file);
+        newImages.push(compressedImage);
+      } catch (error) {
+        console.error('Image compression error:', error);
+        setError(`画像の処理に失敗しました: ${file.name}`);
+      }
+    }
+    
+    setImages(newImages);
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  };
+
+  const removeImage = (index) => {
+    const newImages = images.filter((_, i) => i !== index);
+    setImages(newImages);
+  };
+
+  const insertImagePlaceholder = (index) => {
+    const placeholder = `{{IMAGE:${index}}}`;
+    setContent(content + placeholder);
+  };
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-lg shadow-md p-6">
+        <div className="text-center py-12">
+          <div className="inline-block animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
+          <p className="mt-4 text-gray-600">読み込み中...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <h2 className="text-2xl font-bold text-gray-900 mb-6">このサイトについて - 編集</h2>
+
+      {error && (
+        <div className="mb-4 bg-red-50 border border-red-200 rounded-lg p-4 text-red-700">
+          {error}
+        </div>
+      )}
+
+      {successMessage && (
+        <div className="mb-4 bg-green-50 border border-green-200 rounded-lg p-4 text-green-700">
+          {successMessage}
+        </div>
+      )}
+
+      <div className="mb-6">
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          内容
+        </label>
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+          rows="15"
+          placeholder="サイトの説明を入力してください..."
+        />
+        <p className="mt-2 text-sm text-gray-500">
+          改行は自動的に反映されます。画像を挿入する場合は、下の画像管理から画像をアップロードし、挿入ボタンをクリックしてください。
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">画像管理</h3>
+        
+        <div className="mb-4">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            onChange={handleImageUpload}
+            className="hidden"
+            id="image-upload"
+          />
+          <label
+            htmlFor="image-upload"
+            className="inline-flex items-center px-4 py-2 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 cursor-pointer"
+          >
+            画像を追加
+          </label>
+        </div>
+
+        {images.length > 0 && (
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {images.map((image, index) => (
+              <div key={index} className="relative group">
+                <img
+                  src={image}
+                  alt={`画像 ${index + 1}`}
+                  className="w-full h-32 object-cover rounded-lg"
+                />
+                <div className="absolute inset-0 bg-black bg-opacity-50 opacity-0 group-hover:opacity-100 transition-opacity rounded-lg flex items-center justify-center gap-2">
+                  <button
+                    onClick={() => insertImagePlaceholder(index)}
+                    className="bg-blue-500 text-white px-2 py-1 rounded text-sm hover:bg-blue-600"
+                  >
+                    挿入
+                  </button>
+                  <button
+                    onClick={() => removeImage(index)}
+                    className="bg-red-500 text-white px-2 py-1 rounded text-sm hover:bg-red-600"
+                  >
+                    削除
+                  </button>
+                </div>
+                <div className="mt-1 text-xs text-gray-500 text-center">
+                  {`{{IMAGE:${index}}}`}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex justify-end gap-4">
+        <button
+          onClick={handleSave}
+          disabled={saving}
+          className={`px-6 py-2 rounded-lg font-medium ${
+            saving
+              ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
+              : 'bg-blue-600 text-white hover:bg-blue-700'
+          }`}
+        >
+          {saving ? '保存中...' : '保存'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/AboutPageEditor.js
+++ b/src/components/AboutPageEditor.js
@@ -23,7 +23,18 @@ export default function AboutPageEditor() {
       
       const data = await response.json();
       setContent(data.content || '');
-      setImages(data.images || []);
+      // 画像データが文字列の配列の場合、オブジェクトの配列に変換
+      if (data.images && Array.isArray(data.images)) {
+        const processedImages = data.images.map(img => {
+          if (typeof img === 'string') {
+            return { base64: img };
+          }
+          return img;
+        });
+        setImages(processedImages);
+      } else {
+        setImages([]);
+      }
     } catch (err) {
       setError(err.message);
     } finally {
@@ -68,7 +79,7 @@ export default function AboutPageEditor() {
     for (const file of files) {
       try {
         const result = await compressImageToBase64(file);
-        newImages.push(result.base64);
+        newImages.push(result);
       } catch (error) {
         console.error('Image compression error:', error);
         setError(`画像の処理に失敗しました: ${file.name}`);
@@ -160,7 +171,7 @@ export default function AboutPageEditor() {
             {images.map((image, index) => (
               <div key={index} className="relative group">
                 <img
-                  src={image}
+                  src={typeof image === 'object' && image.base64 ? image.base64 : image}
                   alt={`画像 ${index + 1}`}
                   className="w-full h-32 object-cover rounded-lg"
                 />

--- a/src/components/AboutPageEditor.js
+++ b/src/components/AboutPageEditor.js
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-import { compressImage } from '../lib/image-compression';
+import { compressImageToBase64 } from '../lib/image-utils';
 
 export default function AboutPageEditor() {
   const [content, setContent] = useState('');
@@ -67,8 +67,8 @@ export default function AboutPageEditor() {
     
     for (const file of files) {
       try {
-        const compressedImage = await compressImage(file);
-        newImages.push(compressedImage);
+        const result = await compressImageToBase64(file);
+        newImages.push(result.base64);
       } catch (error) {
         console.error('Image compression error:', error);
         setError(`画像の処理に失敗しました: ${file.name}`);

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -59,6 +59,17 @@ export default function Layout({ children }) {
             {/* ナビゲーションメニュー */}
             <div className="flex items-center space-x-1 sm:space-x-2">
               
+              {/* 速読についてリンク */}
+              <Link 
+                href="/fluency" 
+                className={`relative px-2 sm:px-4 py-1 sm:py-2 rounded-lg sm:rounded-xl font-medium transition-all duration-300 text-xs sm:text-sm ${
+                  pathname === '/fluency' 
+                    ? 'text-white bg-gradient-to-r from-blue-600 to-purple-600 shadow-lg shadow-blue-500/25' // アクティブ状態
+                    : 'text-gray-700 hover:text-white hover:bg-gradient-to-r hover:from-blue-500 hover:to-purple-500 hover:shadow-lg hover:shadow-blue-500/25' // 非アクティブ状態
+                }`}
+              >
+                <span className="relative z-10">「速読」について</span>
+              </Link>
               
               {/* このサイトについてリンク */}
               <Link 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -60,7 +60,7 @@ export default function Layout({ children }) {
             <div className="flex items-center space-x-1 sm:space-x-2">
               
               
-              {/* 速読説明ページリンク */}
+              {/* このサイトについてリンク */}
               <Link 
                 href="/about" 
                 className={`relative px-2 sm:px-4 py-1 sm:py-2 rounded-lg sm:rounded-xl font-medium transition-all duration-300 text-xs sm:text-sm ${
@@ -69,7 +69,7 @@ export default function Layout({ children }) {
                     : 'text-gray-700 hover:text-white hover:bg-gradient-to-r hover:from-blue-500 hover:to-purple-500 hover:shadow-lg hover:shadow-blue-500/25' // 非アクティブ状態
                 }`}
               >
-                <span className="relative z-10">「速読」について</span>
+                <span className="relative z-10">このサイトについて</span>
               </Link>
               
               {/* 読解練習ページリンク - メインCTA */}


### PR DESCRIPTION
## Summary
- 管理者が自由に編集できる「このサイトについて」ページを実装しました
- DBにAboutPageテーブルを追加し、APIエンドポイントを作成
- 管理画面から簡単にページ全体を編集できる機能を追加

## 実装内容
- **DBスキーマ**: `AboutPage`テーブルを追加（content, images フィールド）
- **API**: `/api/about` エンドポイント（GET/PUT）を実装
- **フロントエンド**: 既存の/aboutページを動的コンテンツ対応に変更
- **管理画面**: 「このサイトについて」編集タブを追加
- **画像対応**: Base64画像のアップロードと{{IMAGE:n}}プレースホルダー機能

## 使い方
1. `/admin`（パスワード: gorira）にアクセス
2. 「このサイトについて」タブを選択
3. テキストエリアに内容を入力（改行は自動的に反映）
4. 画像を追加する場合は「画像を追加」ボタンから
5. 画像挿入位置に{{IMAGE:番号}}を記入
6. 「保存」ボタンで更新

## Test plan
- [ ] `/about`ページが正しく表示されることを確認
- [ ] 管理画面から内容を編集し、保存できることを確認
- [ ] 画像のアップロードと表示が正しく動作することを確認
- [ ] エラーハンドリングが適切に動作することを確認

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)