### PR TITLE
feat: 目立つSTARTボタンをホームページに追加 (#27)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -347,6 +347,63 @@ input::placeholder, textarea::placeholder {
   animation: gradient 3s ease infinite;
 }
 
+/* START button animations */
+@keyframes pulse-glow {
+  0%, 100% {
+    box-shadow: 
+      0 0 20px rgba(59, 130, 246, 0.4),
+      0 0 40px rgba(59, 130, 246, 0.2),
+      0 0 60px rgba(59, 130, 246, 0.1),
+      0 10px 25px -3px rgba(0, 0, 0, 0.2);
+    transform: scale(1);
+  }
+  50% {
+    box-shadow: 
+      0 0 40px rgba(59, 130, 246, 0.6),
+      0 0 80px rgba(59, 130, 246, 0.4),
+      0 0 120px rgba(59, 130, 246, 0.2),
+      0 10px 30px -3px rgba(0, 0, 0, 0.3);
+    transform: scale(1.05);
+  }
+}
+
+@keyframes text-pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.05);
+  }
+}
+
+@keyframes shine {
+  0% {
+    background-position: -200% center;
+  }
+  100% {
+    background-position: 200% center;
+  }
+}
+
+.animate-pulse-glow {
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+.animate-text-pulse {
+  animation: text-pulse 2s ease-in-out infinite;
+}
+
+.animate-shine {
+  background: linear-gradient(
+    105deg,
+    transparent 40%,
+    rgba(255, 255, 255, 0.7) 50%,
+    transparent 60%
+  );
+  background-size: 200% 100%;
+  animation: shine 3s linear infinite;
+}
+
 /* 小さい画面での余白調整 */
 @media (max-width: 480px) {
   .max-w-4xl {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -77,9 +77,15 @@ export default function Home() {
           <div className="flex flex-col sm:flex-row gap-6 justify-center items-center">
             <Link 
               href="/reading"
-              className="group relative px-10 py-5 text-xl font-bold text-white bg-gradient-to-r from-blue-600 to-purple-600 rounded-full overflow-hidden shadow-2xl transform hover:scale-105 transition-all duration-300"
+              className="group relative px-8 sm:px-12 py-5 sm:py-6 text-xl sm:text-2xl font-black text-white bg-gradient-to-r from-blue-600 to-purple-600 rounded-full overflow-hidden shadow-2xl transform hover:scale-110 transition-all duration-300 animate-pulse-glow"
             >
-              <span className="relative z-10">今すぐ始める</span>
+              <div className="absolute inset-0 animate-shine"></div>
+              <span className="relative z-10 flex items-center gap-2 sm:gap-3">
+                <svg className="w-6 h-6 sm:w-8 sm:h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+                </svg>
+                <span className="animate-text-pulse">START</span>
+              </span>
               <div className="absolute inset-0 bg-gradient-to-r from-purple-600 to-pink-600 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
             </Link>
             
@@ -429,12 +435,15 @@ export default function Home() {
           
           <Link 
             href="/reading"
-            className="group relative inline-flex items-center justify-center px-12 py-6 text-2xl font-bold text-gray-800 bg-white rounded-full shadow-2xl hover:shadow-3xl transform hover:scale-105 transition-all duration-300"
+            className="group relative inline-flex items-center justify-center px-10 sm:px-14 py-5 sm:py-7 text-2xl sm:text-3xl font-black text-gray-800 bg-white rounded-full shadow-2xl hover:shadow-3xl transform hover:scale-110 transition-all duration-300 animate-pulse-glow"
           >
-            <span className="relative z-10">速読練習を始める</span>
-            <svg className="w-6 h-6 ml-3 transform group-hover:translate-x-2 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
-            </svg>
+            <div className="absolute inset-0 rounded-full animate-shine"></div>
+            <span className="relative z-10 flex items-center gap-3 sm:gap-4">
+              <svg className="w-8 h-8 sm:w-10 sm:h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={3} d="M13 7l5 5m0 0l-5 5m5-5H6" />
+              </svg>
+              <span className="animate-text-pulse">START</span>
+            </span>
           </Link>
 
           <div className="mt-8">


### PR DESCRIPTION
## Summary
- ホームページに目立つSTARTボタンを追加し、初回ユーザーの導線を改善
- パルス・グロー効果でボタンをより目立たせる
- レスポンシブデザインで全デバイスに対応

## Changes
- ヒーローセクションのCTAボタンを「START」に変更
- CSS アニメーション（pulse-glow, text-pulse, shine）を追加
- ボタンサイズを拡大（px-12 py-6、text-2xl）
- 矢印アイコンを追加してアクションを視覚化
- モバイル向けのレスポンシブ調整を実装
- 最下部のCTAボタンも同様にデザイン強化

## Testing
- ✅ 開発サーバーで動作確認済み
- ✅ レスポンシブデザインの確認済み（モバイル・デスクトップ）
- ✅ アニメーション効果の動作確認済み
- ✅ リンク先（/reading）への遷移確認済み
- ✅ ESLint実行済み（警告のみ、エラーなし）

## Screenshots
実装後のSTARTボタンは以下の特徴を持ちます：
- パルス効果で常に注目を集める
- ホバー時にスケールアップ＋色変化
- シャイン効果で高級感を演出
- 明確な矢印アイコンでアクションを示す

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)